### PR TITLE
Update software_setup.md

### DIFF
--- a/docs/software_setup.md
+++ b/docs/software_setup.md
@@ -21,6 +21,7 @@
 - ``sudo apt-get install git``
 
 ### Installing SugarPiDisplay
+- ``cd ~/``
 - ``git clone https://github.com/bassettb/SugarPiDisplay.git``
 - ``pip3 install SugarPiDisplay/``
 - ``SugarPiDisplay/install.sh``


### PR DESCRIPTION
If you clone the repository to a location other than the base pi home folder, the install script will fail. There's definitely a code solution to this (target cwd), but for time being it may help out the non-technical users who pass through here to have this step noted :)